### PR TITLE
Site: Add dark-mode support

### DIFF
--- a/doc_root/assets/css/master.css
+++ b/doc_root/assets/css/master.css
@@ -203,3 +203,27 @@ nav ul li a:hover {
         opacity: 0;
     }
 }
+
+/**
+ * Dark Mode
+ */
+ @media (prefers-color-scheme: dark) {
+    .logging {
+        background: var(--black);
+    }
+
+    body {
+        background-color: var(--black) !important;
+        color: var(--white) !important;
+    }
+
+    input[type="number"], input[type="date"], input[type="search"], input[type="text"], input[type="tel"], input[type="url"], input[type="password"], input[type="email"], select, textarea {
+        background-color: var(--light-grey) !important;
+        border: 1px solid var(--light-border) !important;
+        color: var(--white) !important;
+    }
+
+    nav ul li a:hover {
+        color: var(--white);
+    }
+}

--- a/doc_root/assets/css/master.css
+++ b/doc_root/assets/css/master.css
@@ -223,7 +223,16 @@ nav ul li a:hover {
         color: var(--white) !important;
     }
 
-    nav ul li a:hover {
+    nav ul li a:hover, button {
         color: var(--white);
+    }
+
+    button:focus, button:hover {
+        color: #888 !important;
+    }
+
+    button:active {
+        color: var(--aqua-blue) !important;
+        border-color: var(--aqua-blue) !important;
     }
 }


### PR DESCRIPTION
This PR adds dark mode support on the default frontend using the new prefers-color-scheme media feature.

Docs: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

Supported by all the latest browser versions.